### PR TITLE
fix: adjust card rarity distribution and layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,17 +112,6 @@ const App: React.FC = () => {
           <Graveyard />
         </div>
       </div>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          gap: "1rem",
-          margin: "1rem 0",
-        }}
-      >
-        <DeckPile />
-        <Graveyard />
-      </div>
       <PromotionModal />
       {!fullView && (
         <Hand

--- a/src/components/DeckPile.tsx
+++ b/src/components/DeckPile.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useCardStore } from '../stores/useCardStore';
-const cardBack = 'src/assets/card-back.png';
+import cardBack from '../assets/card-back.png';
 
 const DeckPile: React.FC = () => {
   const remaining = useCardStore((s) => s.deck.length);

--- a/src/components/Graveyard.tsx
+++ b/src/components/Graveyard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useCardStore } from '../stores/useCardStore';
-const cardBack = 'src/assets/card-back.png';
+import cardBack from '../assets/card-back.png';
 
 const Graveyard: React.FC = () => {
   const graveyard = useCardStore((s) => s.graveyard);

--- a/src/stores/useCardStore.ts
+++ b/src/stores/useCardStore.ts
@@ -6,7 +6,7 @@ export type Card = {
   id: string;
   name: string;
   description: string;
-  rarity: "normal" | "rare" | "epic" | "legendary";
+  rarity: "normal" | "rare" | "epic" | "mythic" | "legendary";
   effectKey: string;
 };
 
@@ -99,7 +99,7 @@ const cardPool: Card[] = [
     id: "ocultas",
     name: "Artes Ocultas",
     description: "Al lanzar esta carta robas otra que no es visible para el rival",
-    rarity: "legendary",
+    rarity: "mythic",
     effectKey: "undoTurn",
   },
   // {
@@ -142,6 +142,7 @@ function buildDeck(): Card[] {
   (Object.keys(rarityCounts) as Card["rarity"][]).forEach((rarity) => {
     const cards = byRarity[rarity];
     const needed = rarityCounts[rarity];
+    if (cards.length === 0) return;
     for (let i = 0; i < needed; i++) {
       const template = cards[i % cards.length];
       deck.push({ ...template, id: `${template.id}-${i}` });

--- a/src/styles/cardColors.ts
+++ b/src/styles/cardColors.ts
@@ -1,7 +1,7 @@
-export const rarityColors: Record<string,string> = {
-    normal:    '#d3d3d3',  // gris claro
-    rare:      '#a8e6cf',  // verde claro
-    epic:      '#d291e4',  // morado claro
-    // mythic:    '#ffb347',  // naranja
-    legendary: '#ffd700',  // dorado
-  };
+export const rarityColors: Record<string, string> = {
+  normal: '#d3d3d3',      // gris claro
+  rare: '#a8e6cf',        // verde claro
+  epic: '#d291e4',        // morado claro
+  mythic: '#ffb347',      // naranja
+  legendary: '#ffd700',   // dorado
+};


### PR DESCRIPTION
## Summary
- support mythic rarity and build deck with 6/5/4/3/2 distribution
- add card-back references and show deck & graveyard piles on board's right
- remove binary card-back asset so image can be added manually at `src/assets/card-back.png`

## Testing
- `npm run lint`
- `npm run build` *(fails: Could not resolve "../assets/card-back.png" from "src/components/Graveyard.tsx")*
- `node - <<'NODE' ... NODE` *(fails: Unknown file extension ".ts" for module)*

------
https://chatgpt.com/codex/tasks/task_e_689bf7073b40832eb0e404a3686e3db2