### PR TITLE
fix: adjust card rarity distribution and layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -50,23 +50,26 @@
 .side-piles {
   position: absolute;
   top: 0;
-  left: calc(100% + 1rem);
+  left: calc(100% + 2rem);
   display: flex;
   flex-direction: column;
   gap: 1rem;
   align-items: center;
+  padding: 1rem 0;
 }
 
 .initial-card,
 .left-panel {
   position: absolute;
   top: 0;
-  right: calc(100% + 1rem);
+  right: calc(100% + 2rem);
 }
 
 .left-panel {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  align-items: center;
+  justify-content: space-between;
+  align-items: flex-start;
+  height: 100%;
+  padding: 1rem 0;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,17 +112,6 @@ const App: React.FC = () => {
           <Graveyard />
         </div>
       </div>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          gap: "1rem",
-          margin: "1rem 0",
-        }}
-      >
-        <DeckPile />
-        <Graveyard />
-      </div>
       <PromotionModal />
       {!fullView && (
         <Hand

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -10,6 +10,7 @@ interface CardProps {
   isSelected: boolean;
   onSelect?: (id: string) => void;
   readOnly?: boolean;
+  showRarity?: boolean;
 }
 
 const CardView: React.FC<CardProps> = ({
@@ -17,6 +18,7 @@ const CardView: React.FC<CardProps> = ({
   isSelected,
   onSelect,
   readOnly,
+  showRarity = true,
 }) => {
   const discardCard = useCardStore((state) => state.discardCard);
 
@@ -47,7 +49,7 @@ const CardView: React.FC<CardProps> = ({
       <p style={{ fontSize: '0.85rem', margin: '0.25rem 0' }}>
         {card.description}
       </p>
-      <small>Rarity: {card.rarity}</small>
+      {showRarity && <small>Rarity: {card.rarity}</small>}
     </div>
   );
 };

--- a/src/components/DeckPile.tsx
+++ b/src/components/DeckPile.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useCardStore } from '../stores/useCardStore';
-const cardBack = 'src/assets/card-back.png';
+import cardBack from '../assets/card-back.jpeg';
 
 const DeckPile: React.FC = () => {
   const remaining = useCardStore((s) => s.deck.length);

--- a/src/components/FaceUpCard.tsx
+++ b/src/components/FaceUpCard.tsx
@@ -27,7 +27,7 @@ const FaceUpCard: React.FC<FaceUpCardProps> = ({ card, small }) => {
       {!small && (
         <p style={{ fontSize: '0.9rem', margin: '0.5rem 0' }}>{card.description}</p>
       )}
-      <small>Rarity: {card.rarity}</small>
+      {!small && <small>Rarity: {card.rarity}</small>}
     </div>
   );
 };

--- a/src/components/Graveyard.tsx
+++ b/src/components/Graveyard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useCardStore } from '../stores/useCardStore';
-const cardBack = 'src/assets/card-back.png';
+import cardBack from '../assets/card-back.jpeg';
 
 const Graveyard: React.FC = () => {
   const graveyard = useCardStore((s) => s.graveyard);

--- a/src/components/Hand.css
+++ b/src/components/Hand.css
@@ -15,8 +15,10 @@
 }
 
 .hand.full {
-  flex-direction: column;
-  align-items: center;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: flex-start;
   margin: 0;
 }
 

--- a/src/components/Hand.tsx
+++ b/src/components/Hand.tsx
@@ -36,6 +36,7 @@ const Hand: React.FC<HandProps> = ({ player, position, readOnly }) => {
           isSelected={!readOnly && selectedCard?.id === card.id}
           onSelect={readOnly ? undefined : selectCard}
           readOnly={readOnly}
+          showRarity={position !== 'full'}
         />
       ))}
     </div>

--- a/src/stores/useCardStore.ts
+++ b/src/stores/useCardStore.ts
@@ -6,7 +6,7 @@ export type Card = {
   id: string;
   name: string;
   description: string;
-  rarity: "normal" | "rare" | "epic" | "legendary";
+  rarity: "normal" | "rare" | "epic" | "mythic" | "legendary";
   effectKey: string;
 };
 
@@ -99,7 +99,7 @@ const cardPool: Card[] = [
     id: "ocultas",
     name: "Artes Ocultas",
     description: "Al lanzar esta carta robas otra que no es visible para el rival",
-    rarity: "legendary",
+    rarity: "mythic",
     effectKey: "undoTurn",
   },
   // {
@@ -142,6 +142,7 @@ function buildDeck(): Card[] {
   (Object.keys(rarityCounts) as Card["rarity"][]).forEach((rarity) => {
     const cards = byRarity[rarity];
     const needed = rarityCounts[rarity];
+    if (cards.length === 0) return;
     for (let i = 0; i < needed; i++) {
       const template = cards[i % cards.length];
       deck.push({ ...template, id: `${template.id}-${i}` });

--- a/src/styles/cardColors.ts
+++ b/src/styles/cardColors.ts
@@ -1,7 +1,7 @@
-export const rarityColors: Record<string,string> = {
-    normal:    '#d3d3d3',  // gris claro
-    rare:      '#a8e6cf',  // verde claro
-    epic:      '#d291e4',  // morado claro
-    // mythic:    '#ffb347',  // naranja
-    legendary: '#ffd700',  // dorado
-  };
+export const rarityColors: Record<string, string> = {
+  normal: '#d3d3d3',      // gris claro
+  rare: '#a8e6cf',        // verde claro
+  epic: '#d291e4',        // morado claro
+  mythic: '#ffb347',      // naranja
+  legendary: '#ffd700',   // dorado
+};


### PR DESCRIPTION
## Summary
- show hands side-by-side in full view and hide rarity labels for compact cards
- add spacing around board and piles and switch card-back references to JPEG
- remove binary card-back asset so image can be added manually at `src/assets/card-back.jpeg`

## Testing
- `npm run lint`
- `npm run build` *(fails: Could not resolve "../assets/card-back.jpeg" from "src/components/DeckPile.tsx")*
- `npx ts-node -e "import { buildInitialDeck } from './src/stores/useCardStore'; console.log(buildInitialDeck().length)"` *(fails: 403 Forbidden fetching ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_689bf7073b40832eb0e404a3686e3db2