### PR TITLE
Ajustes en vista completa y descarte de cartas

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -73,4 +73,5 @@
   align-items: flex-start;
   height: 100%;
   padding: 1rem 0;
+  width: 300px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,13 +96,13 @@ const App: React.FC = () => {
           <div className="left-panel">
             <Hand
               player={localMultiplayer ? (turn === "w" ? "b" : "w") : "b"}
-              position="full"
+              position="full-top"
               readOnly
             />
             {initialFaceUp && <FaceUpCard card={initialFaceUp} small />}
             <Hand
               player={localMultiplayer ? turn : "w"}
-              position="full"
+              position="full-bottom"
             />
           </div>
         )}

--- a/src/components/Hand.css
+++ b/src/components/Hand.css
@@ -14,15 +14,25 @@
   margin-top: 1rem;
 }
 
-.hand.full {
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  align-items: flex-start;
+.hand.full-top,
+.hand.full-bottom {
+  flex-wrap: nowrap;
   margin: 0;
+  width: 100%;
 }
 
-.hand.full .card {
+.hand.full-top {
+  flex-direction: row;
+  justify-content: flex-start;
+}
+
+.hand.full-bottom {
+  flex-direction: row-reverse;
+  justify-content: flex-start;
+}
+
+.hand.full-top .card,
+.hand.full-bottom .card {
   width: 90px;
   padding: 0.5rem;
   margin: 0.25rem;

--- a/src/components/Hand.tsx
+++ b/src/components/Hand.tsx
@@ -1,12 +1,12 @@
 // src/components/Hand.tsx
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useCardStore } from '../stores/useCardStore';
 import CardView from './Card';
 import './Hand.css';
 
 interface HandProps {
   player: 'w' | 'b';
-  position: 'top' | 'bottom' | 'full';
+  position: 'top' | 'bottom' | 'full-top' | 'full-bottom';
   readOnly?: boolean;
 }
 
@@ -15,17 +15,8 @@ const Hand: React.FC<HandProps> = ({ player, position, readOnly }) => {
     player === 'w' ? s.hand : s.opponentHand
   );
   const selectedCard = useCardStore((s) => s.selectedCard);
-  const drawFn = useCardStore((s) =>
-    player === 'w' ? s.drawCard : s.drawOpponentCard
-  );
   const selectCard = useCardStore((s) => s.selectCard);
-
-  // Roba la carta inicial solo si la mano está vacía
-  useEffect(() => {
-    if (hand.length === 0) {
-      drawFn();
-    }
-  }, [drawFn, hand.length]);
+  // No se roba automáticamente al descartar
 
   return (
     <div className={`hand ${position}`}>
@@ -36,7 +27,9 @@ const Hand: React.FC<HandProps> = ({ player, position, readOnly }) => {
           isSelected={!readOnly && selectedCard?.id === card.id}
           onSelect={readOnly ? undefined : selectCard}
           readOnly={readOnly}
-          showRarity={position !== 'full'}
+          showRarity={
+            position !== 'full-top' && position !== 'full-bottom'
+          }
         />
       ))}
     </div>


### PR DESCRIPTION
## Resumen
- Muestra las manos en la vista completa como pilas horizontales a la izquierda del tablero
- Impide robar una carta automáticamente al descartar

## Pruebas
- `npm test` *(falla: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d04f9dc04832e93932573bc9e1494