### PR TITLE
Carta Artes Ocultas y panel de victoria

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -49,28 +49,95 @@
 
 .side-piles {
   position: absolute;
-  top: 0;
-  left: calc(100% + 10rem);
-  top: calc(10% + 1rem);
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   gap: 1rem;
   align-items: center;
-  padding: 1rem 0;
 }
 
-.initial-card,
-.left-panel {
-  position: absolute;
-  top: 0;
+.side-piles.right {
+  left: calc(100% + 2rem);
+}
+
+.side-piles.left {
   right: calc(100% + 2rem);
 }
 
-.left-panel {
+.initial-card {
+  position: absolute;
+  top: 0;
+}
+
+.initial-card.left {
+  right: calc(100% + 2rem);
+}
+
+.initial-card.right {
+  left: calc(100% + 2rem);
+}
+
+.hand-panel {
+  position: absolute;
+  top: 0;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  align-items: flex-start;
   height: 100%;
   padding: 1rem 0;
+  width: 300px;
+}
+
+.hand-panel.left {
+  right: calc(100% + 2rem);
+  align-items: flex-start;
+}
+
+.hand-panel.right {
+  left: calc(100% + 2rem);
+  align-items: flex-end;
+}
+
+.dev-toggle-button {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 1000;
+}
+
+.dev-panel {
+  position: fixed;
+  border: 2px dashed #f00;
+  padding: 1rem;
+  background-color: rgba(97, 97, 100, 0.85);
+  z-index: 999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-align: center;
+  cursor: move;
+}
+
+.dev-panel .add-card {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.victory-panel {
+  position: fixed;
+  border: 2px solid #4caf50;
+  padding: 1rem;
+  background-color: rgba(97, 97, 100, 0.85);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-align: center;
+  cursor: move;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { useChessStore } from "./stores/useChessStore";
 import { useSettingsStore } from "./stores/useSettingsStore";
 import PromotionModal from "./components/PromotionModal";
 import CustomDragLayer from "./components/CustomDragLayer";
+import VictoryPanel from "./components/VictoryPanel";
 import "./App.css";
 // import { WHITE } from "chess.js";
 
@@ -24,6 +25,7 @@ const App: React.FC = () => {
   const turn = useChessStore((s) => s.turn);
   const localMultiplayer = useSettingsStore((s) => s.localMultiplayer);
   const fullView = useSettingsStore((s) => s.fullView);
+  const leftHanded = useSettingsStore((s) => s.leftHanded);
   const [devMode, setDevMode] = useState(false);
   const [theme, setTheme] = useState<"light" | "dark">(() =>
     window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -54,27 +56,11 @@ const App: React.FC = () => {
       <Notification />
       <CustomDragLayer />
 
-      <header
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
-      >
+      <header style={{ textAlign: "center" }}>
         <h1>Magic Chess</h1>
-        <div style={{ display: "flex", gap: "0.5rem" }}>
-          <button
-            onClick={() => setTheme((t) => (t === "dark" ? "light" : "dark"))}
-          >
-            {theme === "dark" ? "☀️ Claro" : "🌙 Oscuro"}
-          </button>
-          <button onClick={() => setDevMode((d) => !d)}>
-            {devMode ? "🔒 Salir Dev Mode" : "🔧 Entrar Dev Mode"}
-          </button>
-        </div>
       </header>
 
-      {devMode && <DevPanel />}
+      {devMode && <DevPanel theme={theme} setTheme={setTheme} />}
 
       <TurnIndicator />
 
@@ -88,37 +74,44 @@ const App: React.FC = () => {
 
       <div className="board-area">
         {!fullView && initialFaceUp && (
-          <div className="initial-card">
+          <div className={`initial-card ${leftHanded ? 'right' : 'left'}`}>
             <FaceUpCard card={initialFaceUp} />
           </div>
         )}
         {fullView && (
-          <div className="left-panel">
+          <div className={`hand-panel ${leftHanded ? 'right' : 'left'}`}>
             <Hand
               player={localMultiplayer ? (turn === "w" ? "b" : "w") : "b"}
-              position="full"
+              position="full-top"
               readOnly
             />
             {initialFaceUp && <FaceUpCard card={initialFaceUp} small />}
             <Hand
               player={localMultiplayer ? turn : "w"}
-              position="full"
+              position="full-bottom"
             />
           </div>
         )}
         <Board rotated={localMultiplayer && turn === "b"} />
-        <div className="side-piles">
+        <div className={`side-piles ${leftHanded ? 'left' : 'right'}`}>
           <DeckPile />
           <Graveyard />
         </div>
       </div>
       <PromotionModal />
+      <VictoryPanel />
       {!fullView && (
         <Hand
           player={localMultiplayer ? turn : "w"}
           position="bottom"
         />
       )}
+      <button
+        className="dev-toggle-button"
+        onClick={() => setDevMode((d) => !d)}
+      >
+        {devMode ? "🔒 Cerrar Dev" : "🔧 Abrir Dev"}
+      </button>
     </div>
   );
 };

--- a/src/components/Card.css
+++ b/src/components/Card.css
@@ -48,3 +48,11 @@
   color: #ff4d4f;
   text-shadow: 0 0 6px #ff4d4f;
 }
+
+.card .hidden-indicator {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  font-weight: bold;
+  font-size: 1.1rem;
+}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -4,6 +4,7 @@ import type { Card } from '../stores/useCardStore';
 import { useCardStore } from '../stores/useCardStore';
 import { rarityColors } from '../styles/cardColors';
 import './Card.css';
+import cardBack from '../assets/card-back.jpeg';
 
 interface CardProps {
   card: Card;
@@ -11,6 +12,10 @@ interface CardProps {
   onSelect?: (id: string) => void;
   readOnly?: boolean;
   showRarity?: boolean;
+  showDescription?: boolean;
+  player: 'w' | 'b';
+  faceDown?: boolean;
+  fullView?: boolean;
 }
 
 const CardView: React.FC<CardProps> = ({
@@ -19,8 +24,13 @@ const CardView: React.FC<CardProps> = ({
   onSelect,
   readOnly,
   showRarity = true,
+  showDescription = true,
+  player,
+  faceDown,
+  fullView,
 }) => {
   const discardCard = useCardStore((state) => state.discardCard);
+  const drawHiddenCard = useCardStore((s) => s.drawHiddenCard);
 
   const handleDiscard = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -30,15 +40,44 @@ const CardView: React.FC<CardProps> = ({
   };
 
   // Background color según rareza
+  if (faceDown) {
+    return (
+      <div className="card back">
+        {fullView ? (
+          <span style={{ fontSize: '2rem' }}>¿?</span>
+        ) : (
+          <img
+            src={cardBack}
+            alt="Carta oculta"
+            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+          />
+        )}
+      </div>
+    );
+  }
+
   const bgColor = rarityColors[card.rarity];
   const cls = `card${isSelected ? ' selected' : ''}`;
 
+  const handleSelect = () => {
+    if (readOnly) return;
+    if (card.effectKey === 'hiddenDraw') {
+      if (window.confirm('¿Consumir "Artes Ocultas"?')) {
+        discardCard(card.id);
+        drawHiddenCard(player);
+      }
+      return;
+    }
+    onSelect?.(card.id);
+  };
+
   return (
     <div
-      onClick={() => onSelect?.(card.id)}
+      onClick={handleSelect}
       className={cls}
       style={{ backgroundColor: bgColor }}
     >
+      {card.hidden && <span className="hidden-indicator">¿?</span>}
       {!readOnly && (
         <button onClick={handleDiscard} className="discard-btn">
           ×
@@ -46,9 +85,11 @@ const CardView: React.FC<CardProps> = ({
       )}
 
       <h4 style={{ margin: '0 0 0.25rem' }}>{card.name}</h4>
-      <p style={{ fontSize: '0.85rem', margin: '0.25rem 0' }}>
-        {card.description}
-      </p>
+      {showDescription && (
+        <p style={{ fontSize: '0.85rem', margin: '0.25rem 0' }}>
+          {card.description}
+        </p>
+      )}
       {showRarity && <small>Rarity: {card.rarity}</small>}
     </div>
   );

--- a/src/components/DeckPile.tsx
+++ b/src/components/DeckPile.tsx
@@ -6,7 +6,13 @@ const DeckPile: React.FC = () => {
   const remaining = useCardStore((s) => s.deck.length);
   return (
     <div style={{ textAlign: 'center' }}>
-      <div style={{ position: 'relative', width: 80, height: 120 }}>
+      <div
+        style={{
+          position: 'relative',
+          width: 'calc(var(--square) * 8 / 3)',
+          height: 'calc(var(--square) * 4)',
+        }}
+      >
         <img
           src={cardBack}
           alt="Mazo"

--- a/src/components/DevPanel.tsx
+++ b/src/components/DevPanel.tsx
@@ -1,17 +1,16 @@
 // src/components/DevPanel.tsx
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useCardStore } from '../stores/useCardStore';
 import { useSettingsStore } from '../stores/useSettingsStore';
 
-const DevPanel: React.FC = () => {
-  const deck = useCardStore(s => s.deck);
-  const hand = useCardStore(s => s.hand);
-  const opponentHand = useCardStore(s => s.opponentHand);
-  const initialFaceUp = useCardStore(s => s.initialFaceUp);
-  const selectedCard = useCardStore(s => s.selectedCard);
+interface DevPanelProps {
+  theme: 'light' | 'dark';
+  setTheme: React.Dispatch<React.SetStateAction<'light' | 'dark'>>;
+}
 
-  const drawCard = useCardStore(s => s.drawCard);
-  const drawOpponentCard = useCardStore(s => s.drawOpponentCard);
+const DevPanel: React.FC<DevPanelProps> = ({ theme, setTheme }) => {
+  const deck = useCardStore(s => s.deck);
+
   const clearOpponentHand = useCardStore(s => s.clearOpponentHand);
 
   // Nuevas acciones dev:
@@ -22,45 +21,91 @@ const DevPanel: React.FC = () => {
   const toggleLocalMultiplayer = useSettingsStore(s => s.toggleLocalMultiplayer);
   const fullView = useSettingsStore(s => s.fullView);
   const toggleFullView = useSettingsStore(s => s.toggleFullView);
+  const leftHanded = useSettingsStore(s => s.leftHanded);
+  const toggleLeftHanded = useSettingsStore(s => s.toggleLeftHanded);
+
+  const [selectedCardId, setSelectedCardId] = useState(deck[0]?.id ?? '');
+  const [targetPlayer, setTargetPlayer] = useState<'w' | 'b'>('w');
+  const [position, setPosition] = useState({ x: window.innerWidth / 2, y: window.innerHeight / 2 });
+  const [dragging, setDragging] = useState(false);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+
+  const handleAddCard = () => {
+    if (!selectedCardId) return;
+    if (targetPlayer === 'w') {
+      drawSpecificToHand(selectedCardId);
+    } else {
+      drawSpecificToOpponent(selectedCardId);
+    }
+  };
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (['BUTTON', 'SELECT', 'OPTION'].includes(target.tagName)) return;
+    setOffset({ x: e.clientX - position.x, y: e.clientY - position.y });
+    setDragging(true);
+  };
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!dragging) return;
+      setPosition({ x: e.clientX - offset.x, y: e.clientY - offset.y });
+    };
+    const handleMouseUp = () => setDragging(false);
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [dragging, offset]);
 
   return (
-    <div style={{
-      border: '2px dashed #f00',
-      padding: '1rem',
-      margin: '1rem',
-      backgroundColor: '#616164b3'
-    }}>
+    <div
+      className="dev-panel"
+      style={{ top: position.y, left: position.x, transform: 'translate(-50%, -50%)' }}
+      onMouseDown={handleMouseDown}
+    >
       <h2>🔧 Dev Panel</h2>
 
-      <button onClick={drawCard}>→ Robar carta jugador</button>{' '}
-      <button onClick={drawOpponentCard}>→ Robar carta rival</button>{' '}
-      <button onClick={clearOpponentHand}>× Vaciar mano rival</button>{' '}
+      <button onClick={clearOpponentHand}>× Vaciar mano rival</button>
       <button onClick={toggleLocalMultiplayer}>
         {localMultiplayer ? 'Desactivar modo 2 jugadores' : 'Activar modo 2 jugadores'}
       </button>
       <button onClick={toggleFullView}>
         {fullView ? 'Salir vista completa' : 'Vista completa'}
       </button>
+      <button onClick={toggleLeftHanded}>
+        {leftHanded ? 'Modo diestros' : 'Modo zurdos'}
+      </button>
+      <button onClick={() => setTheme(t => (t === 'dark' ? 'light' : 'dark'))}>
+        {theme === 'dark' ? '☀️ Claro' : '🌙 Oscuro'}
+      </button>
 
-      <h3>Mazo completo:</h3>
-      {deck.map(card => (
-        <div key={card.id} style={{ marginBottom: '0.25rem' }}>
-          {card.name}
-          <button onClick={() => drawSpecificToHand(card.id)} style={{ marginLeft: '0.5rem' }}>
-            + Mi mano
-          </button>
-          <button onClick={() => drawSpecificToOpponent(card.id)} style={{ marginLeft: '0.25rem' }}>
-            + Mano rival
-          </button>
-        </div>
-      ))}
-
-      <ul>
-        <li><strong>Carta mesa:</strong> {initialFaceUp?.id ?? '–'}</li>
-        <li><strong>Mi mano:</strong> {hand.map(c => c.id).join(', ') || '–'}</li>
-        <li><strong>Mano rival:</strong> {opponentHand.map(c => c.id).join(', ') || '–'}</li>
-        <li><strong>Seleccionada:</strong> {selectedCard?.id ?? '–'}</li>
-      </ul>
+      <div className="add-card">
+        <span>Añadir carta</span>
+        <select
+          className="form-select"
+          value={selectedCardId}
+          onChange={e => setSelectedCardId(e.target.value)}
+        >
+          {deck.map(card => (
+            <option key={card.id} value={card.id}>
+              {card.name}
+            </option>
+          ))}
+        </select>
+        <span>al jugador</span>
+        <select
+          className="form-select"
+          value={targetPlayer}
+          onChange={e => setTargetPlayer(e.target.value as 'w' | 'b')}
+        >
+          <option value="w">blanco</option>
+          <option value="b">negro</option>
+        </select>
+        <button onClick={handleAddCard}>Añadir</button>
+      </div>
     </div>
   );
 };

--- a/src/components/Graveyard.tsx
+++ b/src/components/Graveyard.tsx
@@ -8,7 +8,13 @@ const Graveyard: React.FC = () => {
 
   return (
     <div style={{ textAlign: 'center' }}>
-      <div style={{ position: 'relative', width: 80, height: 120 }}>
+      <div
+        style={{
+          position: 'relative',
+          width: 'calc(var(--square) * 8 / 3)',
+          height: 'calc(var(--square) * 4)',
+        }}
+      >
         <img
           src={cardBack}
           alt="Cementerio"

--- a/src/components/Hand.css
+++ b/src/components/Hand.css
@@ -14,16 +14,49 @@
   margin-top: 1rem;
 }
 
-.hand.full {
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  align-items: flex-start;
+.hand.full-top,
+.hand.full-bottom {
+  flex-wrap: nowrap;
   margin: 0;
+  width: 100%;
 }
 
-.hand.full .card {
+.hand.full-top {
+  flex-direction: row;
+  justify-content: flex-start;
+}
+
+.hand.full-bottom {
+  flex-direction: row-reverse;
+  justify-content: flex-start;
+}
+
+.hand-panel.right .hand.full-top {
+  flex-direction: row-reverse;
+}
+
+.hand-panel.right .hand.full-bottom {
+  flex-direction: row;
+}
+
+.hand.full-top .card,
+.hand.full-bottom .card {
   width: 90px;
+  height: 120px;
   padding: 0.5rem;
   margin: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.hand.full-top .card h4,
+.hand.full-bottom .card h4 {
+  font-size: 0.75rem;
+  margin: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 }

--- a/src/components/Hand.tsx
+++ b/src/components/Hand.tsx
@@ -1,12 +1,12 @@
 // src/components/Hand.tsx
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useCardStore } from '../stores/useCardStore';
 import CardView from './Card';
 import './Hand.css';
 
 interface HandProps {
   player: 'w' | 'b';
-  position: 'top' | 'bottom' | 'full';
+  position: 'top' | 'bottom' | 'full-top' | 'full-bottom';
   readOnly?: boolean;
 }
 
@@ -15,17 +15,8 @@ const Hand: React.FC<HandProps> = ({ player, position, readOnly }) => {
     player === 'w' ? s.hand : s.opponentHand
   );
   const selectedCard = useCardStore((s) => s.selectedCard);
-  const drawFn = useCardStore((s) =>
-    player === 'w' ? s.drawCard : s.drawOpponentCard
-  );
   const selectCard = useCardStore((s) => s.selectCard);
-
-  // Roba la carta inicial solo si la mano está vacía
-  useEffect(() => {
-    if (hand.length === 0) {
-      drawFn();
-    }
-  }, [drawFn, hand.length]);
+  // No se roba automáticamente al descartar
 
   return (
     <div className={`hand ${position}`}>
@@ -36,7 +27,15 @@ const Hand: React.FC<HandProps> = ({ player, position, readOnly }) => {
           isSelected={!readOnly && selectedCard?.id === card.id}
           onSelect={readOnly ? undefined : selectCard}
           readOnly={readOnly}
-          showRarity={position !== 'full'}
+          showRarity={
+            position !== 'full-top' && position !== 'full-bottom'
+          }
+          showDescription={
+            position !== 'full-top' && position !== 'full-bottom'
+          }
+          player={player}
+          faceDown={readOnly && card.hidden}
+          fullView={position === 'full-top' || position === 'full-bottom'}
         />
       ))}
     </div>

--- a/src/components/VictoryPanel.tsx
+++ b/src/components/VictoryPanel.tsx
@@ -1,0 +1,57 @@
+// src/components/VictoryPanel.tsx
+import React, { useEffect, useState } from 'react';
+import { useChessStore } from '../stores/useChessStore';
+
+const VictoryPanel: React.FC = () => {
+  const winner = useChessStore((s) => s.winner);
+  const reset = useChessStore((s) => s.reset);
+  const [position, setPosition] = useState({
+    x: window.innerWidth / 2,
+    y: window.innerHeight / 2,
+  });
+  const [dragging, setDragging] = useState(false);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.tagName === 'BUTTON') return;
+    setOffset({ x: e.clientX - position.x, y: e.clientY - position.y });
+    setDragging(true);
+  };
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!dragging) return;
+      setPosition({ x: e.clientX - offset.x, y: e.clientY - offset.y });
+    };
+    const handleMouseUp = () => setDragging(false);
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [dragging, offset]);
+
+  if (!winner) return null;
+
+  const text =
+    winner === 'draw'
+      ? '¡Tablas!'
+      : winner === 'w'
+      ? '¡Ganan las blancas!'
+      : '¡Ganan las negras!';
+
+  return (
+    <div
+      className="victory-panel"
+      style={{ top: position.y, left: position.x, transform: 'translate(-50%, -50%)' }}
+      onMouseDown={handleMouseDown}
+    >
+      <h2>{text}</h2>
+      <button onClick={() => reset()}>Reiniciar</button>
+    </div>
+  );
+};
+
+export default VictoryPanel;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,4 @@
 // src/main.tsx (o index.tsx)
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { DndProvider } from 'react-dnd';
@@ -7,9 +6,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <DndProvider backend={HTML5Backend}>
-      <App />
-    </DndProvider>
-  </React.StrictMode>
+  <DndProvider backend={HTML5Backend}>
+    <App />
+  </DndProvider>
 );

--- a/src/stores/useCardStore.ts
+++ b/src/stores/useCardStore.ts
@@ -8,6 +8,7 @@ export type Card = {
   description: string;
   rarity: "normal" | "rare" | "epic" | "mythic" | "legendary";
   effectKey: string;
+  hidden?: boolean;
 };
 
 const cardPool: Card[] = [
@@ -100,7 +101,7 @@ const cardPool: Card[] = [
     name: "Artes Ocultas",
     description: "Al lanzar esta carta robas otra que no es visible para el rival",
     rarity: "mythic",
-    effectKey: "undoTurn",
+    effectKey: "hiddenDraw",
   },
   // {
   //   id: "cupido",
@@ -164,6 +165,7 @@ interface CardState {
   setInitialFaceUp: () => void;
   drawCard: () => void;
   drawOpponentCard: () => void;
+  drawHiddenCard: (player: Color) => void;
   discardCard: (id: string) => void;
   markFirstCapture: (captorColor: Color) => void;
   selectCard: (id: string) => void;
@@ -208,6 +210,20 @@ export const useCardStore = create<CardState>((set) => ({
       const [card, ...rest] = state.deck;
       return { opponentHand: [...state.opponentHand, card], deck: rest };
 
+    }),
+
+  drawHiddenCard: (player) =>
+    set((state) => {
+      if (state.deck.length === 0) return {};
+      const [card, ...rest] = state.deck;
+      const hiddenCard = { ...card, hidden: true };
+      if (player === "w") {
+        if (state.hand.length >= 3) return {};
+        return { hand: [...state.hand, hiddenCard], deck: rest };
+      } else {
+        if (state.opponentHand.length >= 3) return {};
+        return { opponentHand: [...state.opponentHand, hiddenCard], deck: rest };
+      }
     }),
 
   discardCard: (id) =>
@@ -280,5 +296,9 @@ export const useCardStore = create<CardState>((set) => ({
       return { opponentHand: [...state.opponentHand, card], deck };
     }),
 
-  clearOpponentHand: () => set({ opponentHand: [] }),
+  clearOpponentHand: () =>
+    set((state) => ({
+      opponentHand: [],
+      graveyard: [...state.graveyard, ...state.opponentHand],
+    })),
 }));

--- a/src/stores/useChessStore.ts
+++ b/src/stores/useChessStore.ts
@@ -38,9 +38,10 @@ function isSquareThreatenedByCard(
   const cardStore = useCardStore.getState();
   const oppCards =
     oppColor === "w" ? cardStore.hand : cardStore.opponentHand;
+  const visibleCards = oppCards.filter((c) => !c.hidden);
   const board = game.board() as SquarePiece[][];
 
-  if (oppCards.some((c) => c.effectKey === "queenKnightMove")) {
+  if (visibleCards.some((c) => c.effectKey === "queenKnightMove")) {
     for (let r = 0; r < 8; r++) {
       for (let c = 0; c < 8; c++) {
         const piece = board[r][c];
@@ -59,7 +60,7 @@ function isSquareThreatenedByCard(
     }
   }
 
-  if (oppCards.some((c) => c.effectKey === "pawnBackwardCapture")) {
+  if (visibleCards.some((c) => c.effectKey === "pawnBackwardCapture")) {
     const dir = oppColor === "w" ? -1 : 1;
     for (let r = 0; r < 8; r++) {
       for (let c = 0; c < 8; c++) {
@@ -98,6 +99,9 @@ interface ChessState {
   /** Limpia el mensaje de aviso */
   clearNotification: () => void;
 
+  /** Resultado final de la partida */
+  winner: Color | 'draw' | null;
+
   /** Petición de promoción pendiente, o null si no hay */
   promotionRequest: PromotionRequest | null;
   /** Selecciona pieza de promoción tras petición */
@@ -125,6 +129,7 @@ export const useChessStore = create<ChessState>((set, get) => {
     skipCaptureFor: null,
     notification: null,
     clearNotification: () => set({ notification: null }),
+    winner: null,
 
     // --- PROMOCIÓN ---
     promotionRequest: null,
@@ -232,6 +237,33 @@ export const useChessStore = create<ChessState>((set, get) => {
           c += stepC;
           r += stepR;
         }
+      }
+
+      // --- Captura manual de rey ---
+      if (targetPiece?.type === "k") {
+        const moving = game.get(from as Square);
+        if (!moving) return false;
+        const activeHand =
+          moving.color === "w" ? cardStore.hand : cardStore.opponentHand;
+        const used = effectKey
+          ? activeHand.find((c) => c.effectKey === effectKey)
+          : undefined;
+        const hiddenKill = used?.hidden;
+        game.remove(to as Square);
+        game.remove(from as Square);
+        game.put(moving, to as Square);
+        const nextTurn = moving.color === "w" ? "b" : "w";
+        set({
+          board: game.board() as SquarePiece[][],
+          turn: nextTurn,
+          lastMove: { from, to },
+          winner: hiddenKill ? moving.color : null,
+        });
+        if (used && effectKey && effectKey !== "noCaptureNextTurn") {
+          cardStore.discardCard(used.id);
+          cardStore.selectCard("");
+        }
+        return true;
       }
 
       // --- 5) Efecto kingFreeCastle ---
@@ -522,11 +554,19 @@ export const useChessStore = create<ChessState>((set, get) => {
         }
       }
 
+      if (!get().winner) {
+        if (game.isCheckmate()) {
+          set({ winner: movedColor });
+        } else if (game.isDraw()) {
+          set({ winner: "draw" });
+        }
+      }
+
       return true;
-      } catch (e) {
-        console.error(e);
-        set({ notification: `Error: ${(e as Error).message}` });
-        return false;
+    } catch (e) {
+      console.error(e);
+      set({ notification: `Error: ${(e as Error).message}` });
+      return false;
       }
     },
 
@@ -571,6 +611,7 @@ export const useChessStore = create<ChessState>((set, get) => {
         skipCaptureFor: null,
         notification: null,
         promotionRequest: null,
+        winner: null,
       });
     },
   };

--- a/src/stores/useSettingsStore.ts
+++ b/src/stores/useSettingsStore.ts
@@ -9,6 +9,10 @@ interface SettingsState {
   fullView: boolean;
   /** Toggle full-view layout */
   toggleFullView: () => void;
+  /** Whether layout is flipped for left-handed mode */
+  leftHanded: boolean;
+  /** Toggle left-handed layout */
+  toggleLeftHanded: () => void;
 }
 
 export const useSettingsStore = create<SettingsState>((set) => ({
@@ -17,5 +21,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     set((s) => ({ localMultiplayer: !s.localMultiplayer })),
   fullView: false,
   toggleFullView: () => set((s) => ({ fullView: !s.fullView })),
+  leftHanded: false,
+  toggleLeftHanded: () => set((s) => ({ leftHanded: !s.leftHanded })),
 }));
 


### PR DESCRIPTION
## Resumen
- Reemplaza Artes Ocultas descartando primero y robando carta oculta aun con la mano llena
- Marca las cartas ocultas con un “¿?” y sólo considera cartas visibles para Galope Real y Retirada táctica
- El panel de victoria sólo aparece en jaque mate, tablas o si un rey es capturado con una carta oculta
- Se elimina React.StrictMode para evitar controles duplicados en el DevPanel

## Pruebas
- `npm run lint`
- `npm test` *(falla: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d04f9dc04832e93932573bc9e1494