### PR TITLE
feat: add online multiplayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "chess.js": "^1.4.0",
@@ -19,7 +20,9 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.1.0",
-    "zustand": "^5.0.7"
+    "zustand": "^5.0.7",
+    "socket.io": "^4.7.5",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,44 @@
+import { createServer } from 'node:http';
+import { Server } from 'socket.io';
+
+const httpServer = createServer();
+const io = new Server(httpServer, {
+  cors: {
+    origin: '*',
+  },
+});
+
+io.on('connection', (socket) => {
+  socket.on('join', ({ room, name }) => {
+    socket.data.name = name;
+    socket.data.room = room;
+    socket.join(room);
+    const roomSet = io.sockets.adapter.rooms.get(room) || new Set();
+    if (roomSet.size === 1) {
+      socket.emit('waiting');
+    } else if (roomSet.size === 2) {
+      const [id1, id2] = Array.from(roomSet);
+      const s1 = io.sockets.sockets.get(id1);
+      const s2 = io.sockets.sockets.get(id2);
+      const assignWhite = Math.random() < 0.5;
+      const white = assignWhite ? s1 : s2;
+      const black = assignWhite ? s2 : s1;
+      white.emit('start', { color: 'w', opponent: black.data.name });
+      black.emit('start', { color: 'b', opponent: white.data.name });
+    } else {
+      socket.emit('full');
+    }
+  });
+
+  socket.on('move', ({ from, to, effectKey }) => {
+    const room = socket.data.room;
+    if (room) {
+      socket.to(room).emit('move', { from, to, effectKey });
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3001;
+httpServer.listen(PORT, () => {
+  console.log('Server listening on', PORT);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,11 +17,17 @@ import VictoryPanel from "./components/VictoryPanel";
 import ConfirmModal from "./components/ConfirmModal";
 
 import "./App.css";
+import type { Color } from "chess.js";
+
 // import { WHITE } from "chess.js";
 
 // import type { Card } from "./stores/useCardStore";
 
-const App: React.FC = () => {
+interface AppProps {
+  playerColor?: Color;
+}
+
+const App: React.FC<AppProps> = ({ playerColor }) => {
   const initialFaceUp = useCardStore((s) => s.initialFaceUp);
   const setInitialFaceUp = useCardStore((s) => s.setInitialFaceUp);
   const turn = useChessStore((s) => s.turn);
@@ -69,7 +75,15 @@ const App: React.FC = () => {
 
       {!fullView && (
         <Hand
-          player={localMultiplayer ? (turn === "w" ? "b" : "w") : "b"}
+          player={
+            playerColor
+              ? playerColor === "w"
+                ? "b"
+                : "w"
+              : localMultiplayer
+              ? (turn === "w" ? "b" : "w")
+              : "b"
+          }
           position="top"
           readOnly
         />
@@ -84,18 +98,32 @@ const App: React.FC = () => {
         {fullView && (
           <div className={`hand-panel ${leftHanded ? 'right' : 'left'}`}>
             <Hand
-              player={localMultiplayer ? (turn === "w" ? "b" : "w") : "b"}
+              player={
+                playerColor
+                  ? playerColor === "w"
+                    ? "b"
+                    : "w"
+                  : localMultiplayer
+                  ? (turn === "w" ? "b" : "w")
+                  : "b"
+              }
               position="full-top"
               readOnly
             />
             {initialFaceUp && <FaceUpCard card={initialFaceUp} small />}
             <Hand
-              player={localMultiplayer ? turn : "w"}
+              player={
+                playerColor
+                  ? playerColor
+                  : localMultiplayer
+                  ? turn
+                  : "w"
+              }
               position="full-bottom"
             />
           </div>
         )}
-        <Board rotated={localMultiplayer && turn === "b"} />
+        <Board rotated={playerColor === "b" || (localMultiplayer && turn === "b")} />
         <div className={`side-piles ${leftHanded ? 'left' : 'right'}`}>
           <DeckPile />
           <Graveyard />
@@ -105,7 +133,13 @@ const App: React.FC = () => {
       <VictoryPanel />
       {!fullView && (
         <Hand
-          player={localMultiplayer ? turn : "w"}
+          player={
+            playerColor
+              ? playerColor
+              : localMultiplayer
+              ? turn
+              : "w"
+          }
           position="bottom"
         />
       )}

--- a/src/OnlineGame.tsx
+++ b/src/OnlineGame.tsx
@@ -1,0 +1,115 @@
+import React, { useState, useEffect } from 'react';
+import { io, Socket } from 'socket.io-client';
+import type { Color, Square } from 'chess.js';
+import App from './App';
+import { useChessStore } from './stores/useChessStore';
+import { useCardStore } from './stores/useCardStore';
+
+const SERVER_URL = 'http://localhost:3001';
+
+const OnlineGame: React.FC = () => {
+  const [phase, setPhase] = useState<'login' | 'waiting' | 'playing'>('login');
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
+  const [socket, setSocket] = useState<Socket | null>(null);
+  const [color, setColor] = useState<Color>('w');
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const onWaiting = () => setPhase('waiting');
+    const onStart = ({ color: c }: { color: Color }) => {
+      setColor(c);
+      useChessStore.getState().reset();
+      useCardStore.getState().reset();
+      useChessStore.getState().setOnline(socket, c);
+      setPhase('playing');
+    };
+    const onMove = ({ from, to, effectKey }: { from: Square; to: Square; effectKey?: string }) => {
+      useChessStore.getState().move(from, to, effectKey, true);
+    };
+
+    socket.on('waiting', onWaiting);
+    socket.on('start', onStart);
+    socket.on('move', onMove);
+
+    return () => {
+      socket.off('waiting', onWaiting);
+      socket.off('start', onStart);
+      socket.off('move', onMove);
+    };
+  }, [socket]);
+
+  useEffect(() => {
+    return () => {
+      if (socket) {
+        socket.disconnect();
+        useChessStore.getState().setOnline(null, null);
+      }
+    };
+  }, [socket]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const s = io(SERVER_URL);
+    setSocket(s);
+    setPhase('waiting');
+    useChessStore.getState().reset();
+    useCardStore.getState().reset();
+    s.emit('join', { room: password, name });
+  };
+
+  if (phase === 'login') {
+    return (
+      <div style={{ textAlign: 'center' }}>
+        <h2>Juego en línea</h2>
+        <form onSubmit={handleSubmit} style={{ display: 'inline-block' }}>
+          <div>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Nombre"
+              required
+            />
+          </div>
+          <div>
+            <input
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Contraseña"
+              required
+            />
+          </div>
+          <button type="submit">Entrar</button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <App playerColor={color} />
+      {phase === 'waiting' && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'rgba(0,0,0,0.5)',
+            color: 'white',
+            fontSize: '1.5rem',
+          }}
+        >
+          Esperando otro jugador...
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default OnlineGame;

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import App from './App';
+import OnlineGame from './OnlineGame';
+
+const Root: React.FC = () => {
+  const [mode, setMode] = useState<'start' | 'single' | 'online'>('start');
+
+  if (mode === 'single') {
+    return <App />;
+  }
+  if (mode === 'online') {
+    return <OnlineGame />;
+  }
+  return (
+    <div style={{ textAlign: 'center', padding: '2rem' }}>
+      <h2>Magic Chess</h2>
+      <div style={{ marginTop: '1rem' }}>
+        <button
+          onClick={() => setMode('single')}
+          style={{ margin: '0.5rem', padding: '0.5rem 1rem' }}
+        >
+          Un jugador
+        </button>
+        <button
+          onClick={() => setMode('online')}
+          style={{ margin: '0.5rem', padding: '0.5rem 1rem' }}
+        >
+          Dos jugadores
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Root;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -36,7 +36,7 @@ const CardView: React.FC<CardProps> = ({
   const drawHiddenCard = useCardStore((s) => s.drawHiddenCard);
   const confirm = useConfirmStore((s) => s.show);
   const [tooltip, setTooltip] = useState<{ x: number; y: number } | null>(null);
-  const timer = useRef<number>();
+  const timer = useRef<number | null>(null);
 
 
   const handleDiscard = async (e: React.MouseEvent) => {
@@ -88,7 +88,9 @@ const CardView: React.FC<CardProps> = ({
   };
 
   const handleMouseLeave = () => {
-    window.clearTimeout(timer.current);
+    if (timer.current !== null) {
+      window.clearTimeout(timer.current);
+    }
     setTooltip(null);
   };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,12 @@
 // src/main.tsx (o index.tsx)
 import ReactDOM from 'react-dom/client';
-import App from './App';
+import Root from './Root';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <DndProvider backend={HTML5Backend}>
-    <App />
+    <Root />
   </DndProvider>
 );


### PR DESCRIPTION
## Summary
- add start screen with single or online game options
- implement socket.io server and client for two-player rooms
- orient board by player color and sync moves across players

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'socket.io-client')*


------
https://chatgpt.com/codex/tasks/task_e_689d45869d60832e9f3d333260ef9f78