### PR TITLE
feat: add online multiplayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",
-    "dev": "vite",
+    "dev": "node server/index.js & vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "chess.js": "^1.4.0",
@@ -19,7 +20,9 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.1.0",
-    "zustand": "^5.0.7"
+    "zustand": "^5.0.7",
+    "socket.io": "^4.7.5",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,52 @@
+import { createServer } from 'node:http';
+import { Server } from 'socket.io';
+
+const httpServer = createServer();
+const io = new Server(httpServer, {
+  cors: {
+    origin: '*',
+  },
+});
+
+io.on('connection', (socket) => {
+  socket.on('join', ({ room, name }) => {
+    socket.data.name = name;
+    socket.data.room = room;
+    socket.join(room);
+    const roomSet = io.sockets.adapter.rooms.get(room) || new Set();
+    if (roomSet.size === 1) {
+      socket.emit('waiting');
+    } else if (roomSet.size === 2) {
+      const [id1, id2] = Array.from(roomSet);
+      const s1 = io.sockets.sockets.get(id1);
+      const s2 = io.sockets.sockets.get(id2);
+      const assignWhite = Math.random() < 0.5;
+      const white = assignWhite ? s1 : s2;
+      const black = assignWhite ? s2 : s1;
+      const seed = Math.floor(Math.random() * 1e9);
+      white.emit('start', { color: 'w', seed });
+      black.emit('start', { color: 'b', seed });
+    } else {
+      socket.emit('full');
+    }
+  });
+
+  socket.on('move', ({ from, to, effectKey }) => {
+    const room = socket.data.room;
+    if (room) {
+      socket.to(room).emit('move', { from, to, effectKey });
+    }
+  });
+
+  socket.on('card', (payload) => {
+    const room = socket.data.room;
+    if (room) {
+      socket.to(room).emit('card', payload);
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3001;
+httpServer.listen(PORT, () => {
+  console.log('Server listening on', PORT);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,11 +17,17 @@ import VictoryPanel from "./components/VictoryPanel";
 import ConfirmModal from "./components/ConfirmModal";
 
 import "./App.css";
+import type { Color } from "chess.js";
+
 // import { WHITE } from "chess.js";
 
 // import type { Card } from "./stores/useCardStore";
 
-const App: React.FC = () => {
+interface AppProps {
+  playerColor?: Color;
+}
+
+const App: React.FC<AppProps> = ({ playerColor }) => {
   const initialFaceUp = useCardStore((s) => s.initialFaceUp);
   const setInitialFaceUp = useCardStore((s) => s.setInitialFaceUp);
   const turn = useChessStore((s) => s.turn);
@@ -69,7 +75,15 @@ const App: React.FC = () => {
 
       {!fullView && (
         <Hand
-          player={localMultiplayer ? (turn === "w" ? "b" : "w") : "b"}
+          player={
+            playerColor
+              ? playerColor === "w"
+                ? "b"
+                : "w"
+              : localMultiplayer
+              ? (turn === "w" ? "b" : "w")
+              : "b"
+          }
           position="top"
           readOnly
         />
@@ -84,18 +98,32 @@ const App: React.FC = () => {
         {fullView && (
           <div className={`hand-panel ${leftHanded ? 'right' : 'left'}`}>
             <Hand
-              player={localMultiplayer ? (turn === "w" ? "b" : "w") : "b"}
+              player={
+                playerColor
+                  ? playerColor === "w"
+                    ? "b"
+                    : "w"
+                  : localMultiplayer
+                  ? (turn === "w" ? "b" : "w")
+                  : "b"
+              }
               position="full-top"
               readOnly
             />
             {initialFaceUp && <FaceUpCard card={initialFaceUp} small />}
             <Hand
-              player={localMultiplayer ? turn : "w"}
+              player={
+                playerColor
+                  ? playerColor
+                  : localMultiplayer
+                  ? turn
+                  : "w"
+              }
               position="full-bottom"
             />
           </div>
         )}
-        <Board rotated={localMultiplayer && turn === "b"} />
+        <Board rotated={playerColor === "b" || (localMultiplayer && turn === "b")} />
         <div className={`side-piles ${leftHanded ? 'left' : 'right'}`}>
           <DeckPile />
           <Graveyard />
@@ -105,7 +133,13 @@ const App: React.FC = () => {
       <VictoryPanel />
       {!fullView && (
         <Hand
-          player={localMultiplayer ? turn : "w"}
+          player={
+            playerColor
+              ? playerColor
+              : localMultiplayer
+              ? turn
+              : "w"
+          }
           position="bottom"
         />
       )}

--- a/src/OnlineGame.tsx
+++ b/src/OnlineGame.tsx
@@ -1,0 +1,128 @@
+import React, { useState, useEffect } from 'react';
+import { io, Socket } from 'socket.io-client';
+import type { Color, Square } from 'chess.js';
+import App from './App';
+import { useChessStore } from './stores/useChessStore';
+import { useCardStore } from './stores/useCardStore';
+
+const SERVER_URL = 'http://localhost:3001';
+
+const OnlineGame: React.FC = () => {
+  const [phase, setPhase] = useState<'login' | 'waiting' | 'playing'>('login');
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
+  const [socket, setSocket] = useState<Socket | null>(null);
+  const [color, setColor] = useState<Color>('w');
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const onWaiting = () => setPhase('waiting');
+    const onStart = ({ color: c, seed }: { color: Color; seed: number }) => {
+      setColor(c);
+      useChessStore.getState().reset();
+      const cardState = useCardStore.getState();
+      cardState.reset(seed);
+      cardState.setInitialFaceUp();
+      useChessStore.getState().setOnline(socket, c);
+      setPhase('playing');
+    };
+    const onMove = ({ from, to, effectKey }: { from: Square; to: Square; effectKey?: string }) => {
+      useChessStore.getState().move(from, to, effectKey, true);
+    };
+    const onCard = (data: { action: string; player: Color; id?: string }) => {
+      const cs = useCardStore.getState();
+      if (data.action === 'hiddenDraw') {
+        if (data.id) cs.discardCard(data.id);
+        cs.drawHiddenCard(data.player);
+      } else if (data.action === 'discard' && data.id) {
+        cs.discardCard(data.id);
+      }
+    };
+
+    socket.on('waiting', onWaiting);
+    socket.on('start', onStart);
+    socket.on('move', onMove);
+    socket.on('card', onCard);
+
+    return () => {
+      socket.off('waiting', onWaiting);
+      socket.off('start', onStart);
+      socket.off('move', onMove);
+      socket.off('card', onCard);
+    };
+  }, [socket]);
+
+  useEffect(() => {
+    return () => {
+      if (socket) {
+        socket.disconnect();
+        useChessStore.getState().setOnline(null, null);
+      }
+    };
+  }, [socket]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const s = io(SERVER_URL);
+    setSocket(s);
+    setPhase('waiting');
+    useChessStore.getState().reset();
+    useCardStore.getState().reset();
+    s.emit('join', { room: password, name });
+  };
+
+  if (phase === 'login') {
+    return (
+      <div style={{ textAlign: 'center' }}>
+        <h2>Juego en línea</h2>
+        <form onSubmit={handleSubmit} style={{ display: 'inline-block' }}>
+          <div>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Nombre"
+              required
+            />
+          </div>
+          <div>
+            <input
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Contraseña"
+              required
+            />
+          </div>
+          <button type="submit">Entrar</button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <App playerColor={color} />
+      {phase === 'waiting' && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'rgba(0,0,0,0.5)',
+            color: 'white',
+            fontSize: '1.5rem',
+          }}
+        >
+          Esperando otro jugador...
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default OnlineGame;

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import App from './App';
+import OnlineGame from './OnlineGame';
+
+const Root: React.FC = () => {
+  const [mode, setMode] = useState<'start' | 'single' | 'online'>('start');
+
+  if (mode === 'single') {
+    return <App />;
+  }
+  if (mode === 'online') {
+    return <OnlineGame />;
+  }
+  return (
+    <div style={{ textAlign: 'center', padding: '2rem' }}>
+      <h2>Magic Chess</h2>
+      <div style={{ marginTop: '1rem' }}>
+        <button
+          onClick={() => setMode('single')}
+          style={{ margin: '0.5rem', padding: '0.5rem 1rem' }}
+        >
+          Un jugador
+        </button>
+        <button
+          onClick={() => setMode('online')}
+          style={{ margin: '0.5rem', padding: '0.5rem 1rem' }}
+        >
+          Dos jugadores
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Root;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -6,6 +6,7 @@ import { rarityColors } from '../styles/cardColors';
 import './Card.css';
 import cardBack from '../assets/card-back.jpeg';
 import { useConfirmStore } from '../stores/useConfirmStore';
+import { useChessStore } from '../stores/useChessStore';
 
 
 interface CardProps {
@@ -35,8 +36,9 @@ const CardView: React.FC<CardProps> = ({
   const discardCard = useCardStore((state) => state.discardCard);
   const drawHiddenCard = useCardStore((s) => s.drawHiddenCard);
   const confirm = useConfirmStore((s) => s.show);
+  const socket = useChessStore((s) => s.socket);
   const [tooltip, setTooltip] = useState<{ x: number; y: number } | null>(null);
-  const timer = useRef<number>();
+  const timer = useRef<number | null>(null);
 
 
   const handleDiscard = async (e: React.MouseEvent) => {
@@ -44,6 +46,7 @@ const CardView: React.FC<CardProps> = ({
     const ok = await confirm(`¿Descartar "${card.name}"?`);
     if (ok) {
       discardCard(card.id);
+      socket?.emit('card', { action: 'discard', id: card.id });
     }
   };
 
@@ -88,7 +91,9 @@ const CardView: React.FC<CardProps> = ({
   };
 
   const handleMouseLeave = () => {
-    window.clearTimeout(timer.current);
+    if (timer.current !== null) {
+      window.clearTimeout(timer.current);
+    }
     setTooltip(null);
   };
 
@@ -99,7 +104,7 @@ const CardView: React.FC<CardProps> = ({
       if (ok) {
         discardCard(card.id);
         drawHiddenCard(player);
-
+        socket?.emit('card', { action: 'hiddenDraw', player, id: card.id });
       }
       return;
     }

--- a/src/components/Hand.tsx
+++ b/src/components/Hand.tsx
@@ -1,6 +1,7 @@
 // src/components/Hand.tsx
 import React from 'react';
 import { useCardStore } from '../stores/useCardStore';
+import { useChessStore } from '../stores/useChessStore';
 import CardView from './Card';
 import './Hand.css';
 
@@ -11,9 +12,11 @@ interface HandProps {
 }
 
 const Hand: React.FC<HandProps> = ({ player, position, readOnly }) => {
-  const hand = useCardStore((s) =>
-    player === 'w' ? s.hand : s.opponentHand
-  );
+  const myColor = useChessStore((s) => s.playerColor);
+  const hand = useCardStore((s) => {
+    const isMe = myColor ? player === myColor : player === 'w';
+    return isMe ? s.hand : s.opponentHand;
+  });
   const selectedCard = useCardStore((s) => s.selectedCard);
   const selectCard = useCardStore((s) => s.selectCard);
   // No se roba automáticamente al descartar

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,12 @@
 // src/main.tsx (o index.tsx)
 import ReactDOM from 'react-dom/client';
-import App from './App';
+import Root from './Root';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <DndProvider backend={HTML5Backend}>
-    <App />
+    <Root />
   </DndProvider>
 );

--- a/src/stores/useChessStore.ts
+++ b/src/stores/useChessStore.ts
@@ -2,6 +2,7 @@
 import { create } from "zustand";
 import { Chess } from "chess.js";
 import type { Piece, Color, Square, Move, PieceSymbol } from "chess.js";
+import type { Socket } from "socket.io-client";
 import { useCardStore } from "./useCardStore";
 import { useConfirmStore } from "./useConfirmStore";
 
@@ -110,8 +111,16 @@ interface ChessState {
   promotionRequest: PromotionRequest | null;
   /** Selecciona pieza de promoción tras petición */
   selectPromotion: (pieceType: PieceSymbol) => void;
+  socket: Socket | null;
+  playerColor: Color | null;
+  setOnline: (socket: Socket | null, color: Color | null) => void;
 
-  move: (from: Square, to: Square, effectKey?: string) => Promise<boolean>;
+  move: (
+    from: Square,
+    to: Square,
+    effectKey?: string,
+    remote?: boolean,
+  ) => Promise<boolean>;
   blockSquareAt: (sq: Square) => void;
   reset: () => void;
 }
@@ -134,6 +143,9 @@ export const useChessStore = create<ChessState>((set, get) => {
     notification: null,
     clearNotification: () => set({ notification: null }),
     winner: null,
+    socket: null,
+    playerColor: null,
+    setOnline: (socket, color) => set({ socket, playerColor: color }),
     checkGameEnd: () => {
       const g = get().game;
       if (g.isCheckmate()) {
@@ -166,10 +178,12 @@ export const useChessStore = create<ChessState>((set, get) => {
       // NOTA: aquí podrías añadir lógica extra como robo de carta, descartes, etc.
     },
 
-    move: async (from, to, effectKey) => {
+    move: async (from, to, effectKey, remote = false) => {
       try {
         const cardStore = useCardStore.getState();
         const currentTurn = get().turn;
+        const playerColor = get().playerColor;
+        if (!remote && playerColor && playerColor !== currentTurn) return false;
         const piece = game.get(from as Square);
         if (!piece || piece.color !== currentTurn) return false;
 
@@ -537,6 +551,11 @@ export const useChessStore = create<ChessState>((set, get) => {
           turn: nt,
           lastMove: { from, to },
         });
+        const sock = get().socket;
+        const pc = get().playerColor;
+        if (!remote && sock && pc === movedColor) {
+          sock.emit("move", { from, to, effectKey });
+        }
         get().checkGameEnd();
         return true;
       }
@@ -561,15 +580,16 @@ export const useChessStore = create<ChessState>((set, get) => {
       set(update);
 
       // --- 11) Robar carta si no fue bloqueo ---
+      const me = get().playerColor;
       if (!effectUsed) {
-        if (movedColor === "w") cardStore.drawCard();
+        if (!me || movedColor === me) cardStore.drawCard();
         else cardStore.drawOpponentCard();
       }
 
       // --- 12) Descartar carta usada ---
       if (effectUsed && effectKey && effectKey !== "noCaptureNextTurn") {
         const activeHand =
-          movedColor === "w" ? cardStore.hand : cardStore.opponentHand;
+          !me || movedColor === me ? cardStore.hand : cardStore.opponentHand;
         const used = activeHand.find((c) => c.effectKey === effectKey);
         if (used) {
           cardStore.discardCard(used.id);
@@ -578,7 +598,11 @@ export const useChessStore = create<ChessState>((set, get) => {
       }
 
       get().checkGameEnd();
-
+      const sock = get().socket;
+      const pc = get().playerColor;
+      if (!remote && sock && pc === movedColor) {
+        sock.emit('move', { from, to, effectKey });
+      }
 
       return true;
     } catch (e) {


### PR DESCRIPTION
## Summary
- add start screen with single or online game options
- implement socket.io server and client for two-player rooms
- orient board by player color and sync moves across players
- start socket server alongside Vite during development
- synchronize deck and card actions across clients for consistent multiplayer
- broadcast first-capture moves so both clients stay synchronized
- fix hand display so each player sees their own cards

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'socket.io-client')*


------
https://chatgpt.com/codex/tasks/task_e_689d45869d60832e9f3d333260ef9f78