### PR TITLE
Fix card ownership and Dejavú prompt

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -116,6 +116,13 @@ const CardView: React.FC<CardProps> = ({
       }
       return;
     }
+    if (card.effectKey === 'undoTurn') {
+      const ok = await confirm('¿Deseas usar "DEJAVÚ" y deshacer tu último turno?');
+      if (ok) {
+        useChessStore.getState().move('a1', 'a1', 'undoTurn');
+      }
+      return;
+    }
     onSelect?.(card.id);
   };
 

--- a/src/stores/useCardStore.ts
+++ b/src/stores/useCardStore.ts
@@ -217,13 +217,20 @@ export const useCardStore = create<CardState>((set) => ({
       const [card, ...rest] = state.deck;
       const hiddenCard = { ...card, hidden: true };
       const me = useChessStore.getState().playerColor;
-      if (!me || player === me) {
-        if (state.hand.length >= 3) return {};
-        return { hand: [...state.hand, hiddenCard], deck: rest };
-      } else {
+      if (me) {
+        if (player === me) {
+          if (state.hand.length >= 3) return {};
+          return { hand: [...state.hand, hiddenCard], deck: rest };
+        }
         if (state.opponentHand.length >= 3) return {};
         return { opponentHand: [...state.opponentHand, hiddenCard], deck: rest };
       }
+      if (player === "w") {
+        if (state.hand.length >= 3) return {};
+        return { hand: [...state.hand, hiddenCard], deck: rest };
+      }
+      if (state.opponentHand.length >= 3) return {};
+      return { opponentHand: [...state.opponentHand, hiddenCard], deck: rest };
     }),
 
   discardCard: (id) =>
@@ -254,7 +261,21 @@ export const useCardStore = create<CardState>((set) => ({
         return { hasFirstCapture: true, initialFaceUp: null };
       }
       const me = useChessStore.getState().playerColor;
-      if (!me || captorColor === me) {
+      if (me) {
+        if (captorColor === me) {
+          return {
+            hasFirstCapture: true,
+            hand: [card],
+            initialFaceUp: null,
+          };
+        }
+        return {
+          hasFirstCapture: true,
+          opponentHand: [card],
+          initialFaceUp: null,
+        };
+      }
+      if (captorColor === "w") {
         return {
           hasFirstCapture: true,
           hand: [card],


### PR DESCRIPTION
## Summary
- ensure cards go to the player who moves in single-player
- prompt immediately when selecting the Dejavú card
- keep hidden/first capture draws consistent for local play

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f39156468832eab2794fce842ba6a